### PR TITLE
Logging documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -210,7 +210,17 @@ txaio module
     asyncio.
 
 
-.. autoclass:: txaio.IFailedFuture
+.. py:function:: make_logger()
+
+    Creates and returns an instance of :class:`ILogger`. This can pick
+    up context from where it's instantiated (e.g. the containing class
+    or module) so the best way to use this is to create a logger for
+    each class that produces logs; see the example in
+    :class:`ILogger` 's documentation
+
+
+.. autoclass:: txaio.interfaces.ILogger
+.. autoclass:: txaio.interfaces.IFailedFuture
 
 
 .. _Autobahn|Python: http://autobahn.ws/python/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -156,6 +156,28 @@ txaio module
 
     :raises ValueError: if both callback and errback are None
 
+.. py:function:: failure_message(fail)
+
+    Takes an :class:`txaio.IFailedFuture` instance and returns a
+    formatted message suitable to show to a user. This will be a
+    ``str`` with no newlines for the form: ``{exception_name}:
+    {error_message}`` where ``error_message`` is the result of running
+    ``str()`` on the exception instance (under asyncio) or the result
+    of ``.getErrorMessage()`` on the Failure under Twisted.
+
+
+.. py:function:: failure_traceback(fail)
+
+    Take an :class:`txaio.IFailedFuture` instance and returns the
+    Python ``traceback`` instance associated with the failure.
+
+
+.. py:function:: failure_format_traceback(fail):
+
+    Take an :class:`txaio.IFailedFuture` instance and returns a
+    formatted string showing the traceback. Typically, this will have
+    many newlines in it and look like a "normal" Python traceback.
+
 
 .. py:function:: call_later(delay, func, *args, **kwargs)
 

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -11,4 +11,5 @@ Contents
 
    index
    overview
+   programming-guide
    api

--- a/docs/programming-guide.rst
+++ b/docs/programming-guide.rst
@@ -1,0 +1,74 @@
+Programming Guide
+=================
+
+This section is a work in progress and suggestions are welcome.
+
+
+Logging
+-------
+
+If you are developing a new application, you can take advantage of more structured logging by using txaio's APIs throughout. This API is similar to `Twisted's logging <https://twistedmatrix.com/documents/current/core/howto/logger.html>`_ in many ways, but not identical. If you're integrating txaio into existing code, it should "play nicely" with the ``logging`` module, Twisted's newest logger, and the pre-15.2.0 "legacy" Twisted logger.
+
+To create an object suitable for logging, call :func:`txaio.make_logger`. This will return an instance which has a series of methods indicating the "severity" or "level" of the log -- see :class:`txaio.interfaces.ILogger` for an example and more details.
+
+So, given some code like::
+
+    import txaio
+    txaio.use_twisted()
+
+    class Bunny(object):
+        log = txaio.make_logger()
+
+        def hop(self, times=1):
+            self.log.trace("Bunny.hop(times={times})", times=times)
+            self.log.debug("Hopping {times} times.", times=times)
+            try:
+                1 / 0
+            except Exception:
+                fail = txaio.create_failure()
+                self.log.critical(txaio.failure_format_traceback(fail))
+
+    print("output before start_logging")
+    txaio.start_logging(level='debug')
+    print("output after start_logging")
+    jack = Bunny()
+    jack.hop(42)
+
+Then you should see output approximately like this::
+
+    output before start_logging
+    2016-01-21T01:02:03-0100 output after start_logging
+    2016-01-21T01:02:03-0100 Hopping 42 times.
+    2016-01-21T01:02:03-0100 Traceback (most recent call last):
+      File "logging-example.py", line 21, in <module>
+        jack.hop(42)
+    --- <exception caught here> ---
+      File "logging-example.py", line 12, in hop
+        raise RuntimeError("Fox spotted!")
+    exceptions.RuntimeError: Fox spotted!
+
+
+Note that the ``trace``-level message wasn't logged. If you don't like to see full tracebacks except with debugging, you can use this idiom::
+
+    self.log.critical(txaio.failure_message(fail))
+    self.log.debug(txaio.failure_format_traceback(fail))
+
+It's worth noting the code doesn't change at all if you do ``.use_asyncio()`` at the top instead -- of course this is the whole point of ``txaio``!
+
+
+Logging Interoperability
+------------------------
+
+When you're using libraries that are already doing logging, but not using the ``txaio`` APIs, you shouldn't need to do anything. For example::
+
+    import txaio
+    txaio.use_twisted()
+
+
+    def existing_code():
+        from twisted.python import log
+        log.msg("A legacy Twisted logger message")
+
+    txaio.start_logging(level='debug')
+    existing_code()
+

--- a/docs/programming-guide.rst
+++ b/docs/programming-guide.rst
@@ -72,3 +72,16 @@ When you're using libraries that are already doing logging, but not using the ``
     txaio.start_logging(level='debug')
     existing_code()
 
+If you're using ``asyncio`` (or just built-in Python logging), it could look like this::
+
+    import txaio
+    txaio.use_asyncio()
+
+
+    def existing_code():
+        import logging
+        log = logging.getLogger("roy")
+        log.info("Python stdlib message: %s", "txaio was here")
+
+    txaio.start_logging(level='debug')
+    existing_code()

--- a/txaio/interfaces.py
+++ b/txaio/interfaces.py
@@ -50,9 +50,10 @@ class ILogger(object):
 
     All the log methods have the same signature, they just differ in
     what "log level" they represent to the handlers/emitters. The
-    ``message`` argument is a format string using PEP3101-style
-    references to things from the ``kwargs``. Note that there are also
-    the following keys added to the ``kwargs``: log_time and log_level.
+    ``message`` argument is a format string using `PEP3101
+    <https://www.python.org/dev/peps/pep-3101/>`_-style references to
+    things from the ``kwargs``. Note that there are also the following
+    keys added to the ``kwargs``: ``log_time`` and ``log_level``.
 
     For example::
 


### PR DESCRIPTION
Added missing logging/IFailedFuture API docs and a "programming guide" to contain some prose documentation/best-practices to use txaio logging.