### PR TITLE
Fix test_sdist not finding setup.py or sdist

### DIFF
--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -37,7 +37,7 @@ import txaio
 def test_sdist():
     if not hasattr(subprocess, 'check_output'):
         pytest.skip()
-    subprocess.check_output([sys.executable, 'setup.py', 'sdist'], cwd='..')
+    subprocess.check_output([sys.executable, 'setup.py', 'sdist'],)
     tmp = tempfile.mkdtemp()
     try:
         subprocess.check_output([
@@ -47,7 +47,7 @@ def test_sdist():
             'install',
             '--target', tmp,
             '--no-deps',
-            '../dist/txaio-{}.tar.gz'.format(txaio.__version__),
+            'dist/txaio-{}.tar.gz'.format(txaio.__version__),
         ])
     finally:
         rmtree(tmp)


### PR DESCRIPTION
Fix test_packaging:test_sdist which was failing with the following errors running py.test from the sdist root:

```
test/test_packaging.py:40:
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

popenargs = (['/usr/local/bin/python2.7', 'setup.py', 'sdist'],), kwargs = {'cwd': '..'}, process = <subprocess.Popen object at 0x8058db5d0>, output = '', unused_err = None, retcode = 2
cmd = ['/usr/local/bin/python2.7', 'setup.py', 'sdist']
<snip>
------- Captured stderr call ------------
/usr/local/bin/python2.7: can't open file 'setup.py': [Errno 2] No such file or directory
```
Subsequently, test_sdist failed finding the resulting sdist tarball, with the following error:

```
E           CalledProcessError: Command '['/usr/local/bin/python2.7', '-m', 'pip', 'install', '--target', '/tmp/tmptcRmwE', '--no-deps', '../dist/txaio-2.2.1.tar.gz']' returned non-zero exit stat
us 2

/usr/local/lib/python2.7/subprocess.py:573: CalledProcessError
----------------------------- Captured stderr call ---------------------------------------------------------------------------------------
Requirement '../dist/txaio-2.2.1.tar.gz' looks like a filename, but the file does not exist
```

This change fixes those issues accordingly:

* Fix test_packaging:test_sdist to work from the sdist root, as it cannot
  find setup.py due to cwd=../ being set, assuming the test is being run
  from the test/ directory.

* Fix validating the resulting sdist (.tar.gz), as the path includes a ../, which
  is incorrect (created in ./dist)