### PR TITLE
Asyncio logging

### DIFF
--- a/docs/programming-guide.rst
+++ b/docs/programming-guide.rst
@@ -85,3 +85,11 @@ If you're using ``asyncio`` (or just built-in Python logging), it could look lik
 
     txaio.start_logging(level='debug')
     existing_code()
+
+
+Starting Logging Yourself
+-------------------------
+
+If you are already starting your favourite logging system yourself (be that Twiste'd logger via ``globalLogBeginner`` or Python stdlib logging), any library using txaio's logging should play nicely with it. **Not** ever calling :func:`txaio.start_logging` has a slight drawback, however: as part of setting up logging, we re-bind all the "unused" logging methods to do-nothing. For example, if the log level is set to ``'info'`` than the ``.debug`` method on all txaio-created logger instances becomes a no-op.
+
+For fully-worked examples of this, look in ``examples/log_interop_stdlib.py`` and ``examples/log_interop_twisted.py``.

--- a/test/test_legacy_logging.py
+++ b/test/test_legacy_logging.py
@@ -1,0 +1,53 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import print_function
+
+import txaio
+
+
+def test_log_stdlib(framework_aio):
+    # for cases when we never call start_logging(), ensure we didn't
+    # no-op out the info messages.
+    import logging
+
+    lg = logging.getLogger()
+    lg.setLevel(logging.INFO)
+    records = []
+
+    class TestHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record.msg)
+    handler = TestHandler()
+    lg.addHandler(handler)
+
+    try:
+        log = txaio.make_logger()
+        log.info("foo={foo}", foo='bar')
+    finally:
+        lg.removeHandler(handler)
+
+    assert 'foo=bar' in records

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -111,7 +111,8 @@ def _log(logger, level, log_format=u'', **kwargs):
     # args, not kwargs.
     if level == 'trace':
         level = 'debug'
-    getattr(logger._logger, level)(log_format, kwargs)
+    msg = log_format.format(**kwargs)
+    getattr(logger._logger, level)(msg)
 
 
 def _no_op(*args, **kw):
@@ -128,7 +129,7 @@ class _TxaioLogWrapper(ILogger):
         # this binds either _log or _no_op above to this instance,
         # depending on the desired level.
         for (idx, name) in enumerate(log_levels):
-            if idx < target_level:
+            if idx <= target_level:
                 log_method = functools.partial(_log, self, name)
             else:
                 log_method = _no_op


### PR DESCRIPTION
This fixes https://github.com/crossbario/autobahn-python/issues/596 and adds a "how interop works when you start logging yourself" section to the programming guide, plus examples of interop with stdlib and Twisted new-logger (where you *don't* call ``txaio.start_logging``)