### PR TITLE
Add in emit() for CB use

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -113,6 +113,37 @@ def test_trace(handler, framework):
     txaio.set_global_log_level(old_log)
 
 
+def test_emit_noop(handler, framework):
+    """
+    emit() with a too-low level is an no-op.
+    """
+    logger = txaio.make_logger()
+
+    old_log = txaio.get_global_log_level()
+    txaio.set_global_log_level("info")
+
+    logger.emit("debug", "foobar")
+
+    assert len(handler.messages) == 0
+    txaio.set_global_log_level(old_log)
+
+
+def test_emit_ok(handler, framework):
+    """
+    emit() with an OK level emits the message.
+    """
+    logger = txaio.make_logger()
+
+    old_log = txaio.get_global_log_level()
+    txaio.set_global_log_level("trace")
+
+    logger.emit("trace", "foobar")
+
+    assert len(handler.messages) == 1
+    assert handler.messages[0].endswith(b"foobar")
+    txaio.set_global_log_level(old_log)
+
+
 def test_bad_failures(handler, framework):
     # just ensuring this doesn't explode
     txaio.failure_format_traceback("not a failure")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -108,9 +108,10 @@ def test_trace(handler, framework):
         "trace {txaio_trace}",
     )
 
+    txaio.set_global_log_level(old_log)
+
     assert len(handler.messages) == 1
     assert handler.messages[0].endswith(b"trace True")
-    txaio.set_global_log_level(old_log)
 
 
 def test_emit_noop(handler, framework):
@@ -124,8 +125,9 @@ def test_emit_noop(handler, framework):
 
     logger.emit("debug", "foobar")
 
-    assert len(handler.messages) == 0
     txaio.set_global_log_level(old_log)
+
+    assert len(handler.messages) == 0
 
 
 def test_emit_ok(handler, framework):
@@ -139,9 +141,10 @@ def test_emit_ok(handler, framework):
 
     logger.emit("trace", "foobar")
 
+    txaio.set_global_log_level(old_log)
+
     assert len(handler.messages) == 1
     assert handler.messages[0].endswith(b"foobar")
-    txaio.set_global_log_level(old_log)
 
 
 def test_bad_failures(handler, framework):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -140,11 +140,13 @@ def test_emit_ok(handler, framework):
     txaio.set_global_log_level("trace")
 
     logger.emit("trace", "foobar")
+    logger.emit("info", "barbaz")
 
     txaio.set_global_log_level(old_log)
 
-    assert len(handler.messages) == 1
+    assert len(handler.messages) == 2
     assert handler.messages[0].endswith(b"foobar")
+    assert handler.messages[1].endswith(b"barbaz")
 
 
 def test_bad_failures(handler, framework):

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -120,6 +120,12 @@ class _TxaioLogWrapper(ILogger):
         self._logger = logger
         self._set_log_level(_log_level)
 
+    def emit(self, level, *args, **kwargs):
+
+        func = getattr(self, level)
+        return func(*args, **kwargs)
+
+
     def _set_log_level(self, level):
         target_level = log_levels.index(level)
         # this binds either _log or _no_op above to this instance,
@@ -130,6 +136,7 @@ class _TxaioLogWrapper(ILogger):
             else:
                 log_method = _no_op
             setattr(self, name, log_method)
+        self._log_level = level
 
 
 class _TxaioFileHandler(logging.Handler, object):

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -121,10 +121,8 @@ class _TxaioLogWrapper(ILogger):
         self._set_log_level(_log_level)
 
     def emit(self, level, *args, **kwargs):
-
         func = getattr(self, level)
         return func(*args, **kwargs)
-
 
     def _set_log_level(self, level):
         target_level = log_levels.index(level)

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -156,15 +156,15 @@ class Logger(object):
         self._logger.emit(level, *args, **kwargs)
 
     def emit(self, level, *args, **kwargs):
-        if not self._log_level_const:
+
+        if log_levels.index(self._log_level) < log_levels.index(level):
             return
 
-        level = LogLevel.lookupByName(level)
+        if level == "trace":
+            return self._trace(*args, **kwargs)
 
-        if level < self._log_level_const:
-                return
-        else:
-            return self._log(level, *args, **kwargs)
+        level = LogLevel.lookupByName(level)
+        return self._log(level, *args, **kwargs)
 
     def set_log_level(self, level, keep=True):
         """
@@ -193,6 +193,7 @@ class Logger(object):
 
             else:
                 if getattr(self, name, None) in (_no_op, None):
+
                     if name == 'trace':
                         setattr(self, "trace", self._trace)
                     else:
@@ -203,13 +204,6 @@ class Logger(object):
                         setattr(self, "failure", self._failure)
 
         self._log_level = level
-
-        if level == "trace":
-            self._log_level_const = LogLevel.debug
-        elif level:
-            self._log_level_const = LogLevel.lookupByName(level)
-        else:
-            self._log_level_const = None
 
     def _failure(self, *args, **kw):
         return self._logger.failure(*args, **kw)

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -155,6 +155,17 @@ class Logger(object):
     def _log(self, level, *args, **kwargs):
         self._logger.emit(level, *args, **kwargs)
 
+    def emit(self, level, *args, **kwargs):
+        if not self._log_level_const:
+            return
+
+        level = LogLevel.lookupByName(level)
+
+        if level < self._log_level_const:
+                return
+        else:
+            return self._log(level, *args, **kwargs)
+
     def set_log_level(self, level, keep=True):
         """
         Set the log level. If keep is True, then it will not change along with
@@ -192,6 +203,13 @@ class Logger(object):
                         setattr(self, "failure", self._failure)
 
         self._log_level = level
+
+        if level == "trace":
+            self._log_level_const = LogLevel.debug
+        elif level:
+            self._log_level_const = LogLevel.lookupByName(level)
+        else:
+            self._log_level_const = None
 
     def _failure(self, *args, **kw):
         return self._logger.failure(*args, **kw)


### PR DESCRIPTION
This is used when it's come over the Crossbar rich-logging pipe, then we don't have to getattr().

cc @oberstet 