### PR TITLE
Ticket97 loop arg

### DIFF
--- a/test/test_batched_timers_aio.py
+++ b/test/test_batched_timers_aio.py
@@ -94,7 +94,9 @@ def test_batched_successful_call_explicit_loop(framework_aio):
     def foo(*args, **kw):
         calls.append((args, kw))
 
-    batched = txaio.make_batched_timer(5, loop=new_loop)
+    txa = txaio.with_config(loop=new_loop)
+
+    batched = txa.make_batched_timer(5)
 
     batched.call_later(1, foo, "first call")
     new_loop.advance_time(2.0)

--- a/test/test_call_later.py
+++ b/test/test_call_later.py
@@ -74,8 +74,11 @@ def test_create_future_explicit_loop(framework):
         pytest.skip()
 
     import asyncio
+
     alt_loop = asyncio.new_event_loop()
-    f = txaio.create_future(loop=alt_loop)
+
+    txa = txaio.with_config(loop=alt_loop)
+    f = txa.create_future()
 
     results = []
     f.add_done_callback(lambda r: results.append(r.result()))
@@ -103,7 +106,9 @@ def test_create_future_success_explicit_loop(framework):
 
     import asyncio
     alt_loop = asyncio.new_event_loop()
-    f = txaio.create_future_success('some result', loop=alt_loop)
+    txa = txaio.with_config(loop=alt_loop)
+
+    f = txa.create_future_success('some result')
 
     results = []
     f.add_done_callback(lambda r: results.append(r.result()))
@@ -129,7 +134,8 @@ def test_create_future_failure_explicit_loop(framework):
     import asyncio
     alt_loop = asyncio.new_event_loop()
     the_exception = Exception('bad')
-    f = txaio.create_future_error(the_exception, loop=alt_loop)
+    txa = txaio.with_config(loop=alt_loop)
+    f = txa.create_future_error(the_exception)
 
     results = []
 

--- a/test/util.py
+++ b/test/util.py
@@ -25,6 +25,9 @@
 ###############################################################################
 
 
+import txaio
+
+
 def run_once():
     '''
     A helper that takes one trip through the event-loop to process any
@@ -39,7 +42,7 @@ def run_once():
     try:
         import asyncio
         from asyncio.test_utils import run_once as _run_once
-        return _run_once(asyncio.get_event_loop())
+        return _run_once(txaio.config.loop or asyncio.get_event_loop())
 
     except ImportError:
         import trollius as asyncio

--- a/test/util.py
+++ b/test/util.py
@@ -25,9 +25,6 @@
 ###############################################################################
 
 
-import txaio
-
-
 def run_once():
     '''
     A helper that takes one trip through the event-loop to process any

--- a/txaio/__init__.py
+++ b/txaio/__init__.py
@@ -36,7 +36,7 @@ version = __version__
 # see aio.py for asyncio/trollius implementation
 
 
-class _Config:
+class _Config(object):
     """
     This holds all valid configuration options, accessed as
     class-level variables. For example, if you were using asyncio:
@@ -58,6 +58,7 @@ class _Config:
 
 
 __all__ = (
+    'with_config',              # allow mutliple custom configurations at once
     'using_twisted',            # True if we're using Twisted
     'using_asyncio',            # True if we're using asyncio
     'use_twisted',              # sets the library to use Twisted, or exception

--- a/txaio/_common.py
+++ b/txaio/_common.py
@@ -38,7 +38,7 @@ class _BatchedTimer(IBatchedTimer):
     """
 
     def __init__(self, bucket_milliseconds, chunk_size,
-                 seconds_provider, delayed_call_creator):
+                 seconds_provider, delayed_call_creator, loop=None):
         if bucket_milliseconds <= 0.0:
             raise ValueError(
                 "bucket_milliseconds must be > 0.0"
@@ -48,6 +48,7 @@ class _BatchedTimer(IBatchedTimer):
         self._get_seconds = seconds_provider
         self._create_delayed_call = delayed_call_creator
         self._buckets = dict()  # real seconds -> (IDelayedCall, list)
+        self._loop = loop
 
     def call_later(self, delay, func, *args, **kwargs):
         """

--- a/txaio/_unframework.py
+++ b/txaio/_unframework.py
@@ -46,6 +46,7 @@ def _throw_usage_error(*args, **kw):
 
 
 # all the txaio API methods just raise the error
+with_config = _throw_usage_error
 create_future = _throw_usage_error
 create_future_success = _throw_usage_error
 create_future_error = _throw_usage_error

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -281,16 +281,18 @@ def create_future(result=_unspecified, error=_unspecified, loop=None):
     return f
 
 
-def create_future_success(result):
-    return create_future(result=result)
+def create_future_success(result, loop=None):
+    return create_future(result=result, loop=loop)
 
 
-def create_future_error(error=None):
-    f = create_future()
+def create_future_error(error=None, loop=None):
+    f = create_future(loop=loop)
     reject(f, error)
     return f
 
 
+# XXX how to pass "loop" arg? could pop it out of kwargs, but .. what
+# if you're "as_future"-ing a function that itself takes a "loop" arg?
 def as_future(fun, *args, **kwargs):
     try:
         res = fun(*args, **kwargs)

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -269,11 +269,11 @@ def failure_format_traceback(fail):
 _unspecified = object()
 
 
-def create_future(result=_unspecified, error=_unspecified):
+def create_future(result=_unspecified, error=_unspecified, loop=None):
     if result is not _unspecified and error is not _unspecified:
         raise ValueError("Cannot have both result and error.")
 
-    f = Future(loop=config.loop)
+    f = Future(loop=loop or config.loop)
     if result is not _unspecified:
         resolve(f, result)
     elif error is not _unspecified:


### PR DESCRIPTION
Okay here's how it looks for having "an API object". Sorry the diffs are huge -- but most of it is re-indenting.

The upshot is: we add one new public method ("with_config()" I've called it for now) and all existing code will work as-is. Anyone wanting "multiple custom configs" (which is only "loop" arg anyway) changes their code. So if you have code like:

```python
import txaio

class Foo(object):

    def something_async(self):
        return txaio.create_future()
```

Then you change it to look like this:

```python
import txaio

class Foo(object):
    txa = txaio

    def something_async(self):
        return self.txa.create_future()
```

...and if you wanted a custom loop in `Foo`, then you set `foo.txa = txaio.with_config(loop=custom_loop)` and you're good. So essentially a two-step way to "buy in" to the custom-loop API: 

 1. search-replace all txaio.* calls with "self.obj.*" and set a class-attibute "obj = txaio".
 2. Then for instances that need a custom loop, you replace their `obj` attribute.

Very open to suggestions for the "with_config" method-name!