### PR TITLE
Removed code that sets f._result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,6 @@ env:
   - TOX_ENV=py34-twtrunk
   - TOX_ENV=py34-asyncio
 
-#  - TOX_ENV=py35-tw154
-#  - TOX_ENV=py35-tw165
-#  - TOX_ENV=py35-twtrunk
-#  - TOX_ENV=py35-asyncio
-#
-#  - TOX_ENV=py36-tw154
-#  - TOX_ENV=py36-tw165
-#  - TOX_ENV=py36-twtrunk
-#  - TOX_ENV=py36-asyncio
-
 script:
   - tox -c tox.ini -e $TOX_ENV
 
@@ -70,24 +60,21 @@ matrix:
       env:
       - TOX_ENV=py35-asyncio
 
-    # Python 3.6 currently fails:
-    # https://github.com/crossbario/txaio/issues/83
-    # https://travis-ci.org/crossbario/txaio/builds/192086131
-#    - python: 3.6
-#      env:
-#      - TOX_ENV=py36-tw154
-#
-#    - python: 3.6
-#      env:
-#      - TOX_ENV=py36-tw165
-#
-#    - python: 3.6
-#      env:
-#      - TOX_ENV=py36-twtrunk
-#
-#    - python: 3.6
-#      env:
-#      - TOX_ENV=py36-asyncio
+    - python: 3.6
+      env:
+      - TOX_ENV=py36-tw154
+
+    - python: 3.6
+      env:
+      - TOX_ENV=py36-tw165
+
+    - python: 3.6
+      env:
+      - TOX_ENV=py36-twtrunk
+
+    - python: 3.6
+      env:
+      - TOX_ENV=py36-asyncio
 
 notifications:
    irc:

--- a/test/test_callback.py
+++ b/test/test_callback.py
@@ -59,31 +59,6 @@ def test_callback(framework):
     assert results[0] == "it worked"
 
 
-def test_chained_callback(framework):
-    """
-    Chain two callbacks where the first one alters the value.
-    """
-    calls = []
-
-    def callback0(arg):
-        calls.append(arg)
-        return arg + " pray I do not alter it futher"
-
-    def callback1(arg):
-        calls.append(arg)
-
-    f = txaio.create_future()
-    txaio.add_callbacks(f, callback0, None)
-    txaio.add_callbacks(f, callback1, None)
-    txaio.resolve(f, "the deal")
-
-    run_once()
-
-    assert len(calls) == 2
-    assert calls[0] == "the deal"
-    assert calls[1] == "the deal pray I do not alter it futher"
-
-
 def test_immediate_result(framework):
     f = txaio.create_future_success("it worked")
     results = []

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -437,17 +437,12 @@ class _AsyncioApi(object):
         """
         callback or errback may be None, but at least one must be
         non-None.
-
-        XXX beware the "f._result" hack to get "chainable-callback" type
-        behavior.
         """
         def done(f):
             try:
                 res = f.result()
                 if callback:
-                    x = callback(res)
-                    if x is not None:
-                        f._result = x
+                    callback(res)
             except Exception:
                 if errback:
                     errback(create_failure())


### PR DESCRIPTION
This stopped working from Python 3.6 onwards, as the Future implementation is now written in C.