### PR TITLE
How do include LICENSE files?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,10 +110,6 @@ setup(
     # this flag will make files from MANIFEST.in go into _source_ distributions only
     include_package_data=True,
 
-    # in addition, the following will make the specified files go
-    # into source _and_ bdist distributions!
-    data_files=[('.', ['LICENSE'])],
-
     # this package does not access its own source code or data files
     # as normal operating system files
     zip_safe=True,


### PR DESCRIPTION
This partially reverts commit edab0339f402e84217a99b5acb75ce17fe2bf269.

Using data_files causes LICENSE to be installed in prefix which could clobber another file. Using only MANIFEST will include it in the tarball without this risk.