### PR TITLE
Fix CI by relaxing flake8

### DIFF
--- a/test/test_errback.py
+++ b/test/test_errback.py
@@ -39,7 +39,7 @@ def test_errback(framework):
     txaio.add_callbacks(f, None, err)
     try:
         raise exception
-    except:
+    except RuntimeError:
         fail = txaio.create_failure()
     txaio.reject(f, fail)
 
@@ -135,7 +135,7 @@ def test_errback_reject_no_args(framework):
     txaio.add_callbacks(f, None, err)
     try:
         raise exception
-    except:
+    except RuntimeError:
         txaio.reject(f)
 
     run_once()
@@ -155,7 +155,7 @@ def test_immediate_failure(framework):
     exception = RuntimeError("it failed")
     try:
         raise exception
-    except:
+    except RuntimeError:
         f0 = txaio.create_future_error()
         fail = txaio.create_failure()
 

--- a/test/test_gather.py
+++ b/test/test_gather.py
@@ -100,7 +100,7 @@ def test_gather_no_consume(framework):
     for f in [f0, f1, f2]:
         try:
             await(f)
-        except:
+        except Exception:
             pass
 
     assert len(results) == 0

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -146,7 +146,7 @@ def test_legacy_error_with_traceback(handler, framework):
 
     try:
         raise RuntimeError("the bad stuff")
-    except Exception:
+    except RuntimeError:
         logging.error("bad stuff", exc_info=True)
 
     assert 'RuntimeError: the bad stuff' in str(handler.messages)
@@ -293,7 +293,7 @@ def test_log_converter(handler, framework):
 
     try:
         raise RuntimeError("failed on purpose")
-    except:
+    except RuntimeError:
         logger.failure(None)
 
     output = out.getvalue()

--- a/tox.ini
+++ b/tox.ini
@@ -48,4 +48,4 @@ deps =
 changedir=.
 
 commands =
-    flake8 --max-line-length=119 txaio/ test/
+    flake8 --max-line-length=119 --ignore=E722 txaio/ test/

--- a/tox.ini
+++ b/tox.ini
@@ -48,4 +48,4 @@ deps =
 changedir=.
 
 commands =
-    flake8 --max-line-length=119 --ignore=E722 txaio/ test/
+    flake8 --max-line-length=119 txaio/ test/

--- a/txaio/_iotype.py
+++ b/txaio/_iotype.py
@@ -58,7 +58,7 @@ def guess_stream_needs_encoding(fileobj, default=True):
         elif t is unicode:
             return False
 
-    except:
+    except Exception:
         pass
 
     try:
@@ -71,7 +71,7 @@ def guess_stream_needs_encoding(fileobj, default=True):
             return True
         else:
             return False
-    except:
+    except Exception:
         pass
 
     return default


### PR DESCRIPTION
CI is kind of broken because we are using very broad `except` statements at some places. I have fixed the obvious and simple ones but I believe there are cases where we can't know upfront which exception will be thrown.

So I updated the flake8 parameters to not fail these cases.