### PR TITLE
Warn if as_future() call makes an async-generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,6 @@ matrix:
 
     - python: 3.3
       env:
-      - TOX_ENV=py33-twtrunk
-
-    - python: 3.3
-      env:
       - TOX_ENV=py33-asyncio
 
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -143,6 +143,9 @@ def test_info(handler, framework):
 
 
 def test_legacy_error_with_traceback(handler, framework):
+    if framework.using_twisted:
+        return pytest.skip('test only for asyncio users')
+
     import logging
 
     try:

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -37,7 +37,7 @@ import txaio
 Log = namedtuple('Log', ['args'])
 
 
-class TestHandler(BytesIO):
+class LoggingHandler(BytesIO):
 
     @property
     def messages(self):
@@ -46,7 +46,7 @@ class TestHandler(BytesIO):
         return self.getvalue().split(os.linesep.encode('ascii'))[:-1]
 
 
-_handler = TestHandler()
+_handler = LoggingHandler()
 
 
 @pytest.fixture
@@ -65,6 +65,7 @@ def handler(log_started):
     """
     Resets the global TestHandler instance for each test.
     """
+    global _handler
     _handler.truncate(0)
     _handler.seek(0)
     return _handler

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,9 @@ changedir=test
 usedevelop=true
 
 commands =
-   coverage run --parallel-mode --source=txaio {envbindir}/py.test -s --basetemp={envtmpdir}
+   coverage run --parallel-mode --source=txaio {envbindir}/py.test -v -s --basetemp={envtmpdir}
+# -s: show output immediately
+# -v: one line per test, instead of one dot
 
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py27-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
     pypy-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
     pypy3-{tw154,tw165,twtrunk,asyncio}
-    py33-{tw154,tw165,twtrunk,asyncio}
+    py33-{tw154,tw165,asyncio}
     py34-{tw154,tw165,twtrunk,asyncio}
     py35-{tw154,tw165,twtrunk,asyncio}
     py36-{tw154,tw165,twtrunk,asyncio}

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -55,6 +55,12 @@ except ImportError:
     from trollius import iscoroutine
     from trollius import Future
 
+try:
+    from types import AsyncGeneratorType  # python 3.5+
+except ImportError:
+    class AsyncGeneratorType(object):
+        pass
+
 
 def _create_future_of_loop(loop):
     return loop.create_future()
@@ -397,6 +403,13 @@ class _AsyncioApi(object):
                 return res
             elif iscoroutine(res):
                 return _create_task(res, loop=self._config.loop)
+            elif isinstance(res, AsyncGeneratorType):
+                raise RuntimeError(
+                    "as_future() received an async generator function; does "
+                    "'{}' use 'yield' when you meant 'await'?".format(
+                        str(fun)
+                    )
+                )
             else:
                 return create_future_success(res)
 


### PR DESCRIPTION
I keep doing this, but maybe it's just because I'm coming from `@inlineCallbacks` and `yield` in Twisted? Does this seem like a reasonable thing to error about? Basically, if you do this:

```
async def func():
    yield some_other_thing()
```

...and then call `as_future()` on it, it'll never run -- because it's an async generator. What you *wanted* to write was:

```
async def func():
    await some_other_thing()
```   