### PR TITLE
Add support for gevent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ matrix:
       env:
       - TOX_ENV=py27-asyncio
 
+    - python: 2.7
+      env:
+      - TOX_ENV=py27-gevent
+
 
     - python: pypy
       env:
@@ -70,6 +74,11 @@ matrix:
       env:
       - TOX_ENV=pypy-asyncio
 
+    - python: pypy
+      env:
+      - TOX_ENV=pypy-gevent
+
+
 
     - python: pypy3
       env:
@@ -87,6 +96,11 @@ matrix:
       env:
       - TOX_ENV=pypy3-asyncio
 
+    - python: pypy3
+      env:
+      - TOX_ENV=pypy3-gevent
+
+
 
     - python: 3.3
       env:
@@ -99,6 +113,11 @@ matrix:
     - python: 3.3
       env:
       - TOX_ENV=py33-asyncio
+
+    - python: 3.3
+      env:
+      - TOX_ENV=py33-gevent
+
 
 
     - python: 3.4
@@ -117,6 +136,11 @@ matrix:
       env:
       - TOX_ENV=py34-asyncio
 
+    - python: 3.4
+      env:
+      - TOX_ENV=py34-gevent
+
+
 
     - python: 3.5
       env:
@@ -134,6 +158,11 @@ matrix:
       env:
       - TOX_ENV=py35-asyncio
 
+    - python: 3.5
+      env:
+      - TOX_ENV=py35-gevent
+
+
 
     - python: 3.6
       env:
@@ -150,6 +179,11 @@ matrix:
     - python: 3.6
       env:
       - TOX_ENV=py36-asyncio
+
+    - python: 3.6
+      env:
+      - TOX_ENV=py36-gevent
+
 
 
 notifications:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ import pytest
 
 
 @pytest.fixture(
-    params=['twisted', 'asyncio'],
+    params=['twisted', 'asyncio', 'gevent'],
 )
 def framework(request):
     """
@@ -28,6 +28,8 @@ def framework(request):
             return framework_tx()
         elif request.param == 'asyncio':
             return framework_aio()
+        elif request.param == 'gevent':
+            return framework_gvt()
     except ImportError:
         pytest.skip()
 
@@ -63,5 +65,18 @@ def framework_aio():
         txaio._use_framework(aio)
         txaio._explicit_framework = 'asyncio'
         return aio
+    except ImportError:
+        pytest.skip()
+
+
+@pytest.fixture
+def framework_gvt():
+    try:
+        import txaio
+        from txaio import gvt
+        gvt._loggers = set()
+        txaio._use_framework(gvt)
+        txaio._explicit_framework = 'gevent'
+        return gvt
     except ImportError:
         pytest.skip()

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -13,15 +13,19 @@ def test_create_result(framework):
     f = txaio.create_future(result='foo')
     if txaio.using_twisted:
         assert f.called
-    else:
+    elif txaio.using_asyncio:
         assert f.done()
+    else:
+        assert f.ready()
 
 
 def test_create_error(framework):
     f = txaio.create_future(error=RuntimeError("test"))
     if txaio.using_twisted:
         assert f.called
-    else:
+    elif txaio.using_asyncio:
         assert f.done()
+    else:
+        assert f.ready()
     # cancel the error; we expected it
     txaio.add_callbacks(f, None, lambda _: None)

--- a/test/test_gather.py
+++ b/test/test_gather.py
@@ -103,6 +103,7 @@ def test_gather_no_consume(framework):
         except Exception:
             pass
 
+    # assert txaio.is_called(f2) is True
     assert len(results) == 0
     assert len(errors) == 3
     assert len(calls) == 0

--- a/test/util.py
+++ b/test/util.py
@@ -36,6 +36,11 @@ def run_once():
     if txaio.using_twisted:
         return
 
+    if txaio.using_gevent:
+        import gevent
+        gevent.get_hub().join()
+        return
+
     try:
         import asyncio
         from asyncio.test_utils import run_once as _run_once
@@ -65,6 +70,20 @@ def await(future):
 
     import txaio
     if txaio.using_twisted:
+        return
+
+    if txaio.using_gevent:
+        import gevent
+        # FIXME: this waits for everything, which works, but it would
+        # be nice to selectively wait on a single future.  the problem arose
+        # with gather(), and nested links.
+        gevent.wait()
+        # if hasattr(future, 'wait'):
+        #     future.wait()
+        # else:
+        #     futures = {future}
+        #     # FIXME: recursively look for _links?
+        #     gevent.wait(futures)
         return
 
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 envlist =
     flake8
-    py27-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
-    pypy-{tw121,tw132,tw154,tw165,twtrunk,asyncio}
-    pypy3-{tw154,tw165,twtrunk,asyncio}
-    py33-{tw154,tw165,asyncio}
-    py34-{tw154,tw165,twtrunk,asyncio}
-    py35-{tw154,tw165,twtrunk,asyncio}
-    py36-{tw154,tw165,twtrunk,asyncio}
+    py27-{tw121,tw132,tw154,tw165,twtrunk,asyncio,gevent}
+    pypy-{tw121,tw132,tw154,tw165,twtrunk,asyncio,gevent}
+    pypy3-{tw154,tw165,twtrunk,asyncio,gevent}
+    py33-{tw154,tw165,asyncio,gevent}
+    py34-{tw154,tw165,twtrunk,asyncio,gevent}
+    py35-{tw154,tw165,twtrunk,asyncio,gevent}
+    py36-{tw154,tw165,twtrunk,asyncio,gevent}
 
 [testenv]
 deps =
@@ -30,6 +30,9 @@ deps =
     py27-asyncio: trollius>=2.0
     pypy-asyncio: trollius>=2.0
     py33-asyncio: asyncio>=3.4.3
+
+    ; gevent dependencies
+    gevent: gevent>=1.1
 
 changedir=test
 

--- a/txaio/__init__.py
+++ b/txaio/__init__.py
@@ -61,8 +61,10 @@ __all__ = (
     'with_config',              # allow mutliple custom configurations at once
     'using_twisted',            # True if we're using Twisted
     'using_asyncio',            # True if we're using asyncio
+    'using_gevent',             # True if we're using gevent
     'use_twisted',              # sets the library to use Twisted, or exception
     'use_asyncio',              # sets the library to use asyncio, or exception
+    'use_gevent',               # sets the library to use gevent, or exception
 
     'config',                   # the config instance, access via attributes
 
@@ -112,6 +114,7 @@ def use_twisted():
     import txaio
     txaio.using_twisted = True
     txaio.using_asyncio = False
+    txaio.using_gevent = False
 
 
 def use_asyncio():
@@ -124,6 +127,20 @@ def use_asyncio():
     import txaio
     txaio.using_twisted = False
     txaio.using_asyncio = True
+    txaio.using_gevent = False
+
+
+def use_gevent():
+    global _explicit_framework
+    if _explicit_framework is not None and _explicit_framework != 'gevent':
+        raise RuntimeError("Explicitly using '{}' already".format(_explicit_framework))
+    _explicit_framework = 'gevent'
+    from txaio import gvt
+    _use_framework(gvt)
+    import txaio
+    txaio.using_twisted = False
+    txaio.using_asyncio = False
+    txaio.using_gevent = True
 
 
 def _use_framework(module):
@@ -133,7 +150,7 @@ def _use_framework(module):
     """
     import txaio
     for method_name in __all__:
-        if method_name in ['use_twisted', 'use_asyncio']:
+        if method_name in ['use_twisted', 'use_asyncio', 'use_gevent']:
             continue
         setattr(txaio, method_name,
                 getattr(module, method_name))

--- a/txaio/_unframework.py
+++ b/txaio/_unframework.py
@@ -35,6 +35,7 @@ from txaio import _Config
 
 using_twisted = False
 using_asyncio = False
+using_gevent = False
 config = _Config()
 
 

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -49,6 +49,7 @@ import six
 
 using_twisted = True
 using_asyncio = False
+using_gevent = False
 
 config = _Config()
 _stderr, _stdout = sys.stderr, sys.stdout


### PR DESCRIPTION
I'm not completely sure yet whether this is a terrible idea, but feel free to let me know!

Here is what led me down this path: 

- I'm very interested in porting an existing project to use crossbar.io
- the existing project relies heavily on `gevent`
- [`gevent-websocket`](https://pypi.python.org/pypi/gevent-websocket/) is the only python WAMP server I'm aware of, but it does not support v2 of the WAMP spec
- the code in [`autobahn.wamp`](https://github.com/crossbario/autobahn-python/blob/master/autobahn/wamp/protocol.py) seems fairly self-contained, so I thought that making `txaio` work with `gevent` might be easier than porting all of `autobahn.wamp`.   Then it might be easy for `gevent-websocket` to use `autobahn-python` as a dependency for its WAMP support (at least until `autobahn-python` adds gevent support ;).

It took me only a few hours to get this far, but I'm sure there are a number of edge cases yet to discover.  Before I go any further I'd like to know if this is an idea that is at all appealing to the crossbar.io team.  

