### PR TITLE
fix recently introduced regression

### DIFF
--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -27,7 +27,11 @@
 import asyncio
 from asyncio import iscoroutine
 from asyncio import Future
-from types import AsyncGeneratorType
+try:
+    from types import AsyncGeneratorType
+except ImportError:
+    class AsyncGeneratorType:
+        pass
 import io
 import os
 import sys


### PR DESCRIPTION
class `AsyncGeneratorType` was introduced in python 3.6, which caused our code to fail on python 3.5

as mentioned here https://docs.python.org/3/library/types.html#types.AsyncGeneratorType