### PR TITLE
fix CI deploy by install latest deps, ignoring already installed

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -52,6 +52,6 @@ aws s3 cp --recursive ./dist s3://${AWS_S3_BUCKET_NAME}/wheels
 
 # tell crossbar-builder about this new wheel push
 # get 'wamp' command, always with latest autobahn master
-pip install -U https://github.com/crossbario/autobahn-python/archive/master.zip#egg=autobahn[twisted,serialization,encryption]
+pip install -I https://github.com/crossbario/autobahn-python/archive/master.zip#egg=autobahn[twisted,serialization,encryption]
 # use 'wamp' to notify crossbar-builder
 wamp --max-failures 3 --authid wheel_pusher --url ws://office2dmz.crossbario.com:8008/ --realm webhook call builder.wheel_pushed --keyword name txaio --keyword publish true


### PR DESCRIPTION
Uses that flag https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i

So I think the issue is that `autobahn-python` doesn't have a requirements.txt file, and deps are only read from within the setup.py and pip's default upgrade strategy doesn't work in that case.