### PR TITLE
Fix cancel handling in python 3.8/3.9.

### DIFF
--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -459,8 +459,11 @@ class _AsyncioApi(object):
                 raise RuntimeError("reject requires an IFailedFuture or Exception")
         future.set_exception(error.value)
 
-    def cancel(self, future):
-        future.cancel()
+    def cancel(self, future, msg=None):
+        if sys.version_info >= (3, 9):
+            future.cancel(msg)
+        else:
+            future.cancel()
 
     def create_failure(self, exception=None):
         """
@@ -484,7 +487,7 @@ class _AsyncioApi(object):
                 res = f.result()
                 if callback:
                     callback(res)
-            except Exception:
+            except (Exception, asyncio.CancelledError):
                 if errback:
                     errback(create_failure())
         return future.add_done_callback(done)

--- a/txaio/tx.py
+++ b/txaio/tx.py
@@ -414,7 +414,7 @@ class _TxApi(object):
                 raise RuntimeError("reject requires a Failure or Exception")
         future.errback(error)
 
-    def cancel(self, future):
+    def cancel(self, future, msg=None):
         future.cancel()
 
     def create_failure(self, exception=None):


### PR DESCRIPTION
We need to explicitely catch `asyncio.CancelledError` as of python3.8 as it now inherits from `BaseException` instead of `Exception`.

As of python3.9 a message can be passed to `Future.cancel()`, add an optional kwarg for that and pass it to `Future.cancel()` when available.

Fixes: #166