### PR TITLE
Fix test failures on Python 3.11 due to asyncio.coroutine being removed

### DIFF
--- a/test/test_as_future.py
+++ b/test/test_as_future.py
@@ -102,10 +102,7 @@ def test_as_future_coroutine(framework):
     results = []
     calls = []
 
-    from asyncio import coroutine
-
-    @coroutine
-    def method(*args, **kw):
+    async def method(*args, **kw):
         calls.append((args, kw))
         return 42
     f = txaio.as_future(method, 1, 2, 3, key='word')

--- a/test/test_call_later.py
+++ b/test/test_call_later.py
@@ -171,11 +171,8 @@ def test_explicit_reactor_coroutine(framework):
     if txaio.using_twisted:
         pytest.skip()
 
-    from asyncio import coroutine
-
-    @coroutine
-    def some_coroutine():
-        yield 'nothing'
+    async def some_coroutine():
+        await 'nothing'
 
     with patch.object(txaio.config, 'loop') as fake_loop:
         txaio.as_future(some_coroutine)

--- a/test/test_is_future.py
+++ b/test/test_is_future.py
@@ -42,11 +42,9 @@ def test_is_future_coroutine(framework_aio):
     Returning an immediate value from as_future
     '''
     pytest.importorskip('asyncio')  # 'aio' might be using trollius
-    from asyncio import coroutine
 
-    @coroutine
-    def some_coroutine():
-        yield 'answer'
+    async def some_coroutine():
+        await 'answer'
     obj = some_coroutine()
     assert txaio.is_future(obj)
 


### PR DESCRIPTION
Fixes: #180 