### PR TITLE
FIX: guess_stream_needs_encoding must return False when fileobj is an instance of io.TextIOBase

### DIFF
--- a/txaio/_iotype.py
+++ b/txaio/_iotype.py
@@ -62,4 +62,10 @@ def guess_stream_needs_encoding(fileobj, default=True):
     except Exception:
         pass
 
+    try:
+        import io
+        return not isinstance(fileobj, io.TextIOBase)
+    except Exception:
+        pass
+
     return default


### PR DESCRIPTION
FIX: guess_stream_needs_encoding must return False when fileobj is an instance of io.TextIOBase
because fileobj.write needs a str as parameter, not bytes