### PR TITLE
fix: add support for Python 3.14

### DIFF
--- a/.audit/python314
+++ b/.audit/python314
@@ -1,0 +1,11 @@
+## AI Assistance Disclosure
+
+- [x] I did **not** use AI-assisted tools to help create this pull request.
+- [ ] I used AI-assisted tools to help create this pull request.
+
+- [x] I have read, understood and followed the projects' [AI Policy](../AI_POLICY.rst) when creating this pull request.
+
+Submitted by: @Jenselme
+Date: 2025-09-03
+Related issue(s): #193
+Branch: python314

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         os: [ubuntu-24.04]
 
         # https://github.com/actions/setup-python#specifying-a-pypy-version
-        python-version: ['3.10', '3.12', 'pypy-3.10']
+        python-version: ['3.10', '3.12', '3.14', 'pypy-3.10']
 
     # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

--- a/test/util.py
+++ b/test/util.py
@@ -47,7 +47,7 @@ def run_once():
             from _asyncio_test_utils import run_once as _run_once
         else:
             from asyncio.test_utils import run_once as _run_once
-        return _run_once(txaio.config.loop or asyncio.get_event_loop())
+        return _run_once(txaio.config.loop or _get_loop())
 
     except ImportError:
         import trollius as asyncio
@@ -64,6 +64,16 @@ def run_once():
         loop.stop()
         loop.run_forever()
         asyncio.gather(*asyncio.Task.all_tasks())
+
+
+def _get_loop():
+    import asyncio
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
 
 
 def _await(future):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     flake8
     py310-{tw2210,tw255,twtrunk,asyncio}
     py312-{tw2210,tw255,twtrunk,asyncio}
+    py314-{tw2210,tw255,twtrunk,asyncio}
     pypy310-{tw2210,tw255,twtrunk,asyncio}
 
 # Python 3.11.11 (0253c85bf5f8, Feb 26 2025, 10:42:42)
@@ -21,12 +22,13 @@ envlist =
 python =
     3.10: py310
     3.12: py312
+    3.14: py314
     pypy-3.10: pypy310
 
 
 [testenv]
 deps =
-    pytest==7.2.1
+    pytest==8.4.0
     coverage==7.0.5
     tw2210: twisted==22.10.0
     tw255: twisted==25.5.0

--- a/txaio/aio.py
+++ b/txaio/aio.py
@@ -321,7 +321,12 @@ class _AsyncioApi(object):
         # otherwise give out the event loop of the thread this is called in
         # rather fetching the loop once in __init__, which may not neccessarily
         # be called from the thread we now run the event loop in.
-        return asyncio.get_event_loop()
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
 
     def failure_message(self, fail):
         """


### PR DESCRIPTION
## Description

- Add support for Python 3.14. It didn’t work previously because `asyncio.get_event_loop` now fails if no event loop is active. See https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop and the initial bug report #193 for more details
- Add Python 3.14 to GitHub actions and `tox` matrix.
- Update Pytest to 8.4.0: it’s the first version to officially support Python 3.14 See https://docs.pytest.org/en/stable/changelog.html#pytest-8-4-0-2025-06-02 Previous versions won’t work because of a breaking change in Python’s AST in 3.14.

---

## Related Issue(s)

Closes or relates to #193

---

## Checklist

- [x] I have referenced relevant issue numbers above
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that
      my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] My code follows the style guidelines of this project

---

## AI Assistance Disclosure

Created the relevant file in `.audit`.

## Review of the proposed Python 3.14 compatibility fix
 
_Reviewed by: GitHub Copilot (on behalf of @oberstet)_ See https://github.com/crossbario/txaio/issues/193#issuecomment-3248700967 for the original comment.

The patch ([commit](https://github.com/Jenselme/txaio/commit/2502a42349c515f6014eb9986aac90d407fb9a4b)) correctly addresses Python 3.14 compatibility by adding a fallback when `asyncio.get_event_loop()` raises a `RuntimeError`. If no event loop is running, it creates a new one and sets it. This pattern is now used in both the test utility code and in `txaio/aio.py`.

This approach is:

- **Consistent** with recommendations from Python’s documentation for event loop management in 3.14+.
- **Minimal and targeted** (affects only relevant code).
- **Backwards compatible** with CPython 3.10 and earlier, and also works on PyPy, since the code first tries the legacy method and only falls back if needed.

**Summary:**  
This fix is a robust way to support Python 3.14 and maintain compatibility with older Python versions.
